### PR TITLE
feat: Detect containers by searching the registry

### DIFF
--- a/Classes/Sizes/Rootline.php
+++ b/Classes/Sizes/Rootline.php
@@ -23,6 +23,7 @@ namespace Codappix\ResponsiveImages\Sizes;
  * 02110-1301, USA.
  */
 
+use B13\Container\Tca\Registry;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -83,7 +84,10 @@ final class Rootline
 
     private function determineContentElement(array $data): ContentElementInterface
     {
-        if (str_contains((string) $data['CType'], '_container-')) {
+        if (
+            class_exists(Registry::class)
+            && GeneralUtility::makeInstance(Registry::class)->isContainerElement($data['CType'])
+        ) {
             return new Container($data);
         }
 


### PR DESCRIPTION
Before we checked if a CType contained a specific
string to check if it is a container. This was
open to false positives if a normal content
element also contained this string.

We now check the proper place to detect if a CType is registered as a container.

Related: #6