### PR TITLE
fix: ScalingFactory exception for missing config

### DIFF
--- a/Classes/Domain/Factory/ScalingFactory.php
+++ b/Classes/Domain/Factory/ScalingFactory.php
@@ -35,9 +35,14 @@ final class ScalingFactory
 
     public function getByConfigurationPath(array|string $configurationPath): Scaling
     {
-        $configuration = $this->configurationManager->getByPath($configurationPath);
         $multiplier = [];
         $sizes = [];
+
+        if ($this->configurationManager->isValidPath($configurationPath) === false) {
+            return new Scaling($multiplier, $sizes);
+        }
+
+        $configuration = $this->configurationManager->getByPath($configurationPath);
 
         if (is_array($configuration)) {
             $multiplier = !empty($configuration['multiplier']) ? $configuration['multiplier'] : [];


### PR DESCRIPTION
It can happen that configuration is missing due to container contnet element types being switched.

One container could support multiple colPos and
when the container type is changed the new
container could only support one colPos.

EXT:container does not remove the content elements of the no longer existing column and still fetches those elements in the data processor.

As we process those content elemens further we run into an exception to fetch config for a columns of a container that is not defined.